### PR TITLE
Add support for `.super` suffix in Mill task resolution

### DIFF
--- a/core/resolve/src/mill/resolve/ParseArgs.scala
+++ b/core/resolve/src/mill/resolve/ParseArgs.scala
@@ -92,23 +92,26 @@ private[mill] object ParseArgs {
       : Result[(Option[Segments], Option[Segments])] =
     parse(selectorString, selector(using _)) match {
       case f: Parsed.Failure => Result.Failure(s"Parsing exception ${f.msg}")
-      case Parsed.Success(selector, _) => 
+      case Parsed.Success(selector, _) =>
         // Post-process the segments to handle .super suffix
         val processedSelector = processSuperSuffix(selector)
         Result.Success(processedSelector)
     }
 
-  private def processSuperSuffix(selector: (Option[Segments], Option[Segments])): (Option[Segments], Option[Segments]) = {
+  private def processSuperSuffix(selector: (
+      Option[Segments],
+      Option[Segments]
+  )): (Option[Segments], Option[Segments]) = {
     def processSegments(segments: Option[Segments]): Option[Segments] = {
       segments.map { s =>
         val segmentList = s.value
-        
+
         // Find the first "super" segment and its index
         val superIdx = segmentList.indexWhere {
           case Segment.Label("super") => true
           case _ => false
         }
-        
+
         // If there's no "super" segment or it's the first segment, return the original segments
         if (superIdx == -1 || superIdx == 0) {
           Segments(segmentList)
@@ -116,19 +119,19 @@ private[mill] object ParseArgs {
           // Create the modified segment by appending ".super" to the segment before "super"
           val modifiedSegment = segmentList(superIdx - 1) match {
             case Segment.Label(label) => Segment.Label(s"$label.super")
-            case Segment.Cross(values) => 
+            case Segment.Cross(values) =>
               // For Cross segments, we can't easily append ".super", so we just keep it as is
               Segment.Cross(values)
           }
-          
+
           // Remove the "super" segment and update the previous segment in one operation
           val newList = segmentList.patch(superIdx, Nil, 1).updated(superIdx - 1, modifiedSegment)
-          
+
           Segments(newList)
         }
       }
     }
-    
+
     (processSegments(selector._1), processSegments(selector._2))
   }
 

--- a/core/resolve/src/mill/resolve/ParseArgs.scala
+++ b/core/resolve/src/mill/resolve/ParseArgs.scala
@@ -92,8 +92,45 @@ private[mill] object ParseArgs {
       : Result[(Option[Segments], Option[Segments])] =
     parse(selectorString, selector(using _)) match {
       case f: Parsed.Failure => Result.Failure(s"Parsing exception ${f.msg}")
-      case Parsed.Success(selector, _) => Result.Success(selector)
+      case Parsed.Success(selector, _) => 
+        // Post-process the segments to handle .super suffix
+        val processedSelector = processSuperSuffix(selector)
+        Result.Success(processedSelector)
     }
+
+  private def processSuperSuffix(selector: (Option[Segments], Option[Segments])): (Option[Segments], Option[Segments]) = {
+    def processSegments(segments: Option[Segments]): Option[Segments] = {
+      segments.map { s =>
+        val segmentList = s.value
+        
+        // Find the first "super" segment and its index
+        val superIdx = segmentList.indexWhere {
+          case Segment.Label("super") => true
+          case _ => false
+        }
+        
+        // If there's no "super" segment or it's the first segment, return the original segments
+        if (superIdx == -1 || superIdx == 0) {
+          Segments(segmentList)
+        } else {
+          // Create the modified segment by appending ".super" to the segment before "super"
+          val modifiedSegment = segmentList(superIdx - 1) match {
+            case Segment.Label(label) => Segment.Label(s"$label.super")
+            case Segment.Cross(values) => 
+              // For Cross segments, we can't easily append ".super", so we just keep it as is
+              Segment.Cross(values)
+          }
+          
+          // Remove the "super" segment and update the previous segment in one operation
+          val newList = segmentList.patch(superIdx, Nil, 1).updated(superIdx - 1, modifiedSegment)
+          
+          Segments(newList)
+        }
+      }
+    }
+    
+    (processSegments(selector._1), processSegments(selector._2))
+  }
 
   private def selector[_p: P]: P[(Option[Segments], Option[Segments])] = {
     def wildcard = P("__" | "_")

--- a/core/resolve/src/mill/resolve/Resolve.scala
+++ b/core/resolve/src/mill/resolve/Resolve.scala
@@ -9,6 +9,7 @@ import mill.define.{
   Module,
   NamedTask,
   Segments,
+  Segment,
   TaskModule,
   SelectMode
 }
@@ -63,6 +64,14 @@ private[mill] object Resolve {
             .flatMap(instantiateNamedTask(r, _, cache))
           instantiated.map(Some(_))
 
+        case r: Resolved.SuperTask =>
+          val instantiated = ResolveCore
+            .instantiateModule(rootModule, r.segments.init, cache)
+            .flatMap(mod => 
+              instantiateSuperTask(r, mod, cache)
+            )
+          instantiated.map(Some(_))
+
         case r: Resolved.Command =>
           val instantiated = ResolveCore
             .instantiateModule(rootModule, r.segments.init, cache)
@@ -93,6 +102,8 @@ private[mill] object Resolve {
               directChildrenOrErr.flatMap(directChildren =>
                 directChildren.head match {
                   case r: Resolved.NamedTask => instantiateNamedTask(r, value, cache).map(Some(_))
+                  case r: Resolved.SuperTask => 
+                    instantiateSuperTask(r, value, cache).map(Some(_))
                   case r: Resolved.Command =>
                     instantiateCommand(
                       rootModule,
@@ -139,6 +150,73 @@ private[mill] object Resolve {
     ResolveCore.catchWrapException(
       definition.invoke(p).asInstanceOf[NamedTask[?]]
     )
+  }
+
+  private def instantiateSuperTask(
+      r: Resolved.SuperTask,
+      p: Module,
+      cache: ResolveCore.Cache
+  ): Result[NamedTask[?]] = {
+    // Get the qualifier (if any) from the SuperTask
+    val qualifier = r.qualifier
+    
+    // The base task name is what comes before ".super" in the segment
+    // For "foo.super", the base task name is "foo"
+    // For a qualified super task, we need to extract from the original segment
+    val baseTaskName = {
+      // Try to find the segment that has ".super" in it
+      val segmentWithSuper = r.segments.value.find { 
+        case Segment.Label(name) => name.contains(".super") 
+        case _ => false
+      }
+      
+      segmentWithSuper match {
+        case Some(Segment.Label(name)) => 
+          // Extract the part before ".super"
+          name.split("\\.super").head
+        case _ =>
+          // Fallback: try using the last non-qualifier segment
+          val relevantSegment = if (qualifier.isDefined && r.segments.value.length > 1) {
+            // If there's a qualifier, use the second-to-last segment
+            r.segments.value(r.segments.value.length - 2)
+          } else {
+            // Otherwise use the last segment
+            r.segments.last
+          }
+          
+          relevantSegment match {
+            case Segment.Label(name) => 
+              if (name.contains(".super")) name.split("\\.super").head
+              else name
+            case _ => 
+              throw new IllegalArgumentException(s"Cannot extract base task name from segments: ${r.segments.render}")
+          }
+      }
+    }
+    
+    // Find and instantiate the base task
+    val definition = Reflect
+      .reflect(
+        p.getClass,
+        classOf[NamedTask[?]],
+        _ == baseTaskName,
+        true,
+        getMethods = cache.getMethods
+      )
+      .head
+
+    ResolveCore.catchWrapException {
+      val baseTask = definition.invoke(p).asInstanceOf[NamedTask[?]]
+      
+      new NamedTask[Any] {
+        override def ctx0 = baseTask.ctx0.withSegments(r.segments)
+        override def isPrivate = baseTask.isPrivate
+        override val inputs = baseTask.inputs
+        override def evaluate0 = baseTask.evaluate0
+        
+        override def toString = baseTask.toString
+      }
+    }
   }
 
   private def instantiateCommand(

--- a/core/resolve/src/mill/resolve/Resolve.scala
+++ b/core/resolve/src/mill/resolve/Resolve.scala
@@ -67,7 +67,7 @@ private[mill] object Resolve {
         case r: Resolved.SuperTask =>
           val instantiated = ResolveCore
             .instantiateModule(rootModule, r.segments.init, cache)
-            .flatMap(mod => 
+            .flatMap(mod =>
               instantiateSuperTask(r, mod, cache)
             )
           instantiated.map(Some(_))
@@ -102,7 +102,7 @@ private[mill] object Resolve {
               directChildrenOrErr.flatMap(directChildren =>
                 directChildren.head match {
                   case r: Resolved.NamedTask => instantiateNamedTask(r, value, cache).map(Some(_))
-                  case r: Resolved.SuperTask => 
+                  case r: Resolved.SuperTask =>
                     instantiateSuperTask(r, value, cache).map(Some(_))
                   case r: Resolved.Command =>
                     instantiateCommand(
@@ -159,19 +159,19 @@ private[mill] object Resolve {
   ): Result[NamedTask[?]] = {
     // Get the qualifier (if any) from the SuperTask
     val qualifier = r.qualifier
-    
+
     // The base task name is what comes before ".super" in the segment
     // For "foo.super", the base task name is "foo"
     // For a qualified super task, we need to extract from the original segment
     val baseTaskName = {
       // Try to find the segment that has ".super" in it
-      val segmentWithSuper = r.segments.value.find { 
-        case Segment.Label(name) => name.contains(".super") 
+      val segmentWithSuper = r.segments.value.find {
+        case Segment.Label(name) => name.contains(".super")
         case _ => false
       }
-      
+
       segmentWithSuper match {
-        case Some(Segment.Label(name)) => 
+        case Some(Segment.Label(name)) =>
           // Extract the part before ".super"
           name.split("\\.super").head
         case _ =>
@@ -183,17 +183,19 @@ private[mill] object Resolve {
             // Otherwise use the last segment
             r.segments.last
           }
-          
+
           relevantSegment match {
-            case Segment.Label(name) => 
+            case Segment.Label(name) =>
               if (name.contains(".super")) name.split("\\.super").head
               else name
-            case _ => 
-              throw new IllegalArgumentException(s"Cannot extract base task name from segments: ${r.segments.render}")
+            case _ =>
+              throw new IllegalArgumentException(
+                s"Cannot extract base task name from segments: ${r.segments.render}"
+              )
           }
       }
     }
-    
+
     // Find and instantiate the base task
     val definition = Reflect
       .reflect(
@@ -207,13 +209,13 @@ private[mill] object Resolve {
 
     ResolveCore.catchWrapException {
       val baseTask = definition.invoke(p).asInstanceOf[NamedTask[?]]
-      
+
       new NamedTask[Any] {
         override def ctx0 = baseTask.ctx0.withSegments(r.segments)
         override def isPrivate = baseTask.isPrivate
         override val inputs = baseTask.inputs
         override def evaluate0 = baseTask.evaluate0
-        
+
         override def toString = baseTask.toString
       }
     }

--- a/core/resolve/src/mill/resolve/ResolveCore.scala
+++ b/core/resolve/src/mill/resolve/ResolveCore.scala
@@ -30,6 +30,8 @@ private object ResolveCore {
     case class Module(segments: Segments, cls: Class[?]) extends Resolved
     case class NamedTask(segments: Segments) extends Resolved
     case class Command(segments: Segments) extends Resolved
+    // Special case for super tasks to distinguish them in the caller if needed
+    case class SuperTask(segments: Segments, qualifier: Option[String] = None) extends Resolved
   }
 
   sealed trait Result
@@ -91,6 +93,85 @@ private object ResolveCore {
     s"Cyclic module reference detected at ${segments.render}, " +
       s"it's required to wrap it in ModuleRef."
   }
+
+  /**
+   * Helper object to handle all SuperTask-related operations.
+   * This consolidates all SuperTask logic into a single place.
+   */
+  object SuperTaskHandler {
+    // Using private inline methods for these simple helpers for better performance
+    private inline def extractBaseTaskName(superTaskSegment: String): String = superTaskSegment.stripSuffix(".super")
+      
+    /**
+     * Handles SuperTask resolution during the resolve phase
+     */
+    def resolve(
+        rootModule: BaseModule,
+        singleLabel: String,
+        current: Resolved.Module,
+        tail: List[Segment],
+        querySoFar: Segments,
+        seenModules: Set[Class[?]],
+        cache: Cache
+    ): Either[NotFound, (Seq[Resolved], List[Segment])] = {
+      // Get potential qualifier from the next segment
+      val superQualifier = tail.headOption.collect { case Segment.Label(q) => q }
+      
+      // Resolve the base task name first
+      resolveDirectChildren(
+        rootModule, 
+        current.cls,
+        Some(extractBaseTaskName(singleLabel)),
+        current.segments,
+        cache = cache
+      ) match {
+        case mill.api.Result.Success(resolved) if resolved.nonEmpty =>
+          // Map tasks to SuperTasks with appropriate segments
+          val superTasks = resolved.collect {
+            case Resolved.NamedTask(s) => 
+              // Create a SuperTask with the appropriate segments and qualifier
+              val lastSegment = s.last.value
+              val baseSegments = s.value.init :+ Segment.Label(lastSegment + ".super")
+              val fullSegments = superQualifier.fold(Segments(baseSegments))(q => 
+                Segments(baseSegments :+ Segment.Label(q))
+              )
+              Resolved.SuperTask(fullSegments, superQualifier)
+            case other => other
+          }
+          
+          // If we have a qualifier, skip it in the remaining segments
+          Right((superTasks, if (superQualifier.isDefined) tail.drop(1) else tail))
+          
+        case _ => 
+          Left(notFoundResult(rootModule, querySoFar, current, Segment.Label(singleLabel), cache))
+      }
+    }
+    
+    /**
+     * Handles SuperTask instantiation during the instantiateModule phase
+     */
+    def instantiate(
+        rootModule: BaseModule,
+        current: Module,
+        s: String,
+        segments: Segments,
+        cache: Cache
+    ): mill.api.Result[Module] = {
+      // Check if this is a module or a task and handle accordingly
+      resolveDirectChildren0(
+        rootModule,
+        current.moduleSegments,
+        current.getClass,
+        Some(extractBaseTaskName(s)),
+        cache = cache
+      ).flatMap {
+        case Seq((resolved: Resolved.Module, Some(f))) => f(current)
+        case Seq((resolved: Resolved.NamedTask, _)) => mill.api.Result.Success(current)
+        case unknown => sys.error(s"Unable to resolve single child: rootModule: ${rootModule}, segments: ${segments.render}, current: $current, s: ${s}")
+      }
+    }
+  }
+
   def resolve(
       rootModule: BaseModule,
       remainingQuery: List[Segment],
@@ -142,71 +223,84 @@ private object ResolveCore {
 
         (head, current) match {
           case (Segment.Label(singleLabel), m: Resolved.Module) =>
-            val resOrErr: mill.api.Result[Seq[Resolved]] = singleLabel match {
-              case "__" =>
-                val self = Seq(Resolved.Module(m.segments, m.cls))
-                val transitiveOrErr =
-                  resolveTransitiveChildren(
+            // Check if this is a superTask segment (has .super suffix)
+            if (singleLabel.endsWith(".super")) {
+              SuperTaskHandler.resolve(rootModule, singleLabel, m, tail, querySoFar, seenModules, cache) match {
+                case Right((superTasks, newRemainingQuery)) =>
+                  if (newRemainingQuery.isEmpty) {
+                    Success(superTasks)
+                  } else {
+                    recurse(superTasks)
+                  }
+                case Left(notFound) => notFound
+              }
+            } else {
+              val resOrErr: mill.api.Result[Seq[Resolved]] = singleLabel match {
+                case "__" =>
+                  val self = Seq(Resolved.Module(m.segments, m.cls))
+                  val transitiveOrErr =
+                    resolveTransitiveChildren(
+                      rootModule,
+                      m.cls,
+                      None,
+                      current.segments,
+                      Nil,
+                      seenModules,
+                      cache
+                    )
+
+                  transitiveOrErr.map(transitive => self ++ transitive)
+
+                case "_" =>
+                  resolveDirectChildren(
                     rootModule,
                     m.cls,
                     None,
                     current.segments,
-                    Nil,
+                    cache = cache
+                  )
+
+                case pattern if pattern.startsWith("__:") =>
+                  val typePattern = pattern.split(":").drop(1)
+                  val self = Seq(Resolved.Module(m.segments, m.cls))
+
+                  val transitiveOrErr = resolveTransitiveChildren(
+                    rootModule,
+                    m.cls,
+                    None,
+                    current.segments,
+                    typePattern.toSeq,
                     seenModules,
                     cache
                   )
 
-                transitiveOrErr.map(transitive => self ++ transitive)
+                  transitiveOrErr.map(transitive => self ++ transitive)
 
-              case "_" =>
-                resolveDirectChildren(
-                  rootModule,
-                  m.cls,
-                  None,
-                  current.segments,
-                  cache = cache
-                )
+                case pattern if pattern.startsWith("_:") =>
+                  val typePattern = pattern.split(":").drop(1)
+                  resolveDirectChildren(
+                    rootModule,
+                    m.cls,
+                    None,
+                    current.segments,
+                    typePattern.toSeq,
+                    cache
+                  )
 
-              case pattern if pattern.startsWith("__:") =>
-                val typePattern = pattern.split(":").drop(1)
-                val self = Seq(Resolved.Module(m.segments, m.cls))
+                case _ =>
+                  resolveDirectChildren(
+                    rootModule,
+                    m.cls,
+                    Some(singleLabel),
+                    current.segments,
+                    cache = cache
+                  )
+              }
 
-                val transitiveOrErr = resolveTransitiveChildren(
-                  rootModule,
-                  m.cls,
-                  None,
-                  current.segments,
-                  typePattern.toSeq,
-                  seenModules,
-                  cache
-                )
-
-                transitiveOrErr.map(transitive => self ++ transitive)
-
-              case pattern if pattern.startsWith("_:") =>
-                val typePattern = pattern.split(":").drop(1)
-                resolveDirectChildren(
-                  rootModule,
-                  m.cls,
-                  None,
-                  current.segments,
-                  typePattern.toSeq,
-                  cache
-                )
-
-              case _ =>
-                resolveDirectChildren(
-                  rootModule,
-                  m.cls,
-                  Some(singleLabel),
-                  current.segments,
-                  cache = cache
-                )
-            }
-
-            resOrErr match {
-              case mill.api.Result.Failure(err) => Error(err)
-              case mill.api.Result.Success(res) => recurse(res.distinct)
+              resOrErr match {
+                case mill.api.Result.Failure(err) => Error(err)
+                case mill.api.Result.Success(res) => recurse(res.distinct)
+              }
             }
 
           case (Segment.Cross(cross), m: Resolved.Module) =>
@@ -254,20 +348,26 @@ private object ResolveCore {
       segments.value.foldLeft[mill.api.Result[Module]](mill.api.Result.Success(rootModule)) {
         case (mill.api.Result.Success(current), Segment.Label(s)) =>
           assert(s != "_", s)
-          resolveDirectChildren0(
-            rootModule,
-            current.moduleSegments,
-            current.getClass,
-            Some(s),
-            cache = cache
-          ).flatMap {
-            case Seq((_, Some(f))) => f(current)
-            case unknown =>
-              sys.error(
-                s"Unable to resolve single child " +
-                  s"rootModule: ${rootModule}, segments: ${segments.render}," +
-                  s"current: $current, s: ${s}, unknown: $unknown"
-              )
+          
+          if (s.endsWith(".super")) {
+            SuperTaskHandler.instantiate(rootModule, current, s, segments, cache)
+          } else {
+            // Not a super task, handle normally
+            resolveDirectChildren0(
+              rootModule,
+              current.moduleSegments,
+              current.getClass,
+              Some(s),
+              cache = cache
+            ).flatMap {
+              case Seq((_, Some(f))) => f(current)
+              case unknown =>
+                sys.error(
+                  s"Unable to resolve single child " +
+                    s"rootModule: ${rootModule}, segments: ${segments.render}," +
+                    s"current: $current, s: ${s}, unknown: $unknown"
+                )
+            }
           }
 
         case (mill.api.Result.Success(current), Segment.Cross(vs)) =>
@@ -389,6 +489,7 @@ private object ResolveCore {
         case (Resolved.Module(s, cls), _) => Resolved.Module(segments ++ s, cls)
         case (Resolved.NamedTask(s), _) => Resolved.NamedTask(segments ++ s)
         case (Resolved.Command(s), _) => Resolved.Command(segments ++ s)
+        case (Resolved.SuperTask(s, qualifier), _) => Resolved.SuperTask(segments ++ s, qualifier)
       }
     }
 

--- a/core/resolve/test/src/mill/resolve/ParseArgsTests.scala
+++ b/core/resolve/test/src/mill/resolve/ParseArgsTests.scala
@@ -352,7 +352,7 @@ object ParseArgsTests extends TestSuite {
           )
         )
       }
-      
+
       test("superTasks") {
         test("basic") {
           check(
@@ -364,7 +364,7 @@ object ParseArgsTests extends TestSuite {
             )
           )
         }
-        
+
         test("withAdditionalPath") {
           check(
             Seq("core.compile.super.run"),
@@ -375,7 +375,7 @@ object ParseArgsTests extends TestSuite {
             )
           )
         }
-        
+
         test("withArgs") {
           check(
             Seq("core.compile.super", "arg1", "arg2"),
@@ -408,13 +408,19 @@ object ParseArgsTests extends TestSuite {
             )
           )
         }
-        
+
         test("withMultipleQualifiedSegments") {
           check(
             Seq("foo.bar.super.module.trait.Class"),
             Seq(
               Seq(
-                None -> Seq(Label("foo"), Label("bar.super"), Label("module"), Label("trait"), Label("Class"))
+                None -> Seq(
+                  Label("foo"),
+                  Label("bar.super"),
+                  Label("module"),
+                  Label("trait"),
+                  Label("Class")
+                )
               ) -> Seq.empty
             )
           )
@@ -443,7 +449,14 @@ object ParseArgsTests extends TestSuite {
         test("withCrossSegment") {
           val result = ParseArgs.extractSegments("bridges[2.12.4,jvm].compile.super")
           val expected = Result.Success(
-            (None, Some(Segments(Seq(Label("bridges"), Cross(Seq("2.12.4", "jvm")), Label("compile.super")))))
+            (
+              None,
+              Some(Segments(Seq(
+                Label("bridges"),
+                Cross(Seq("2.12.4", "jvm")),
+                Label("compile.super")
+              )))
+            )
           )
           assert(result == expected)
         }
@@ -451,7 +464,10 @@ object ParseArgsTests extends TestSuite {
         test("withQualifiedClass") {
           val result = ParseArgs.extractSegments("core.compile.super.qux.Baz")
           val expected = Result.Success(
-            (None, Some(Segments(Seq(Label("core"), Label("compile.super"), Label("qux"), Label("Baz")))))
+            (
+              None,
+              Some(Segments(Seq(Label("core"), Label("compile.super"), Label("qux"), Label("Baz"))))
+            )
           )
           assert(result == expected)
         }
@@ -459,7 +475,16 @@ object ParseArgsTests extends TestSuite {
         test("withComplexQualifiedClass") {
           val result = ParseArgs.extractSegments("foo.bar.super.module.trait.Class")
           val expected = Result.Success(
-            (None, Some(Segments(Seq(Label("foo"), Label("bar.super"), Label("module"), Label("trait"), Label("Class")))))
+            (
+              None,
+              Some(Segments(Seq(
+                Label("foo"),
+                Label("bar.super"),
+                Label("module"),
+                Label("trait"),
+                Label("Class")
+              )))
+            )
           )
           assert(result == expected)
         }

--- a/core/resolve/test/src/mill/resolve/ParseArgsTests.scala
+++ b/core/resolve/test/src/mill/resolve/ParseArgsTests.scala
@@ -352,7 +352,118 @@ object ParseArgsTests extends TestSuite {
           )
         )
       }
+      
+      test("superTasks") {
+        test("basic") {
+          check(
+            Seq("core.compile.super"),
+            Seq(
+              Seq(
+                None -> Seq(Label("core"), Label("compile.super"))
+              ) -> Seq.empty
+            )
+          )
+        }
+        
+        test("withAdditionalPath") {
+          check(
+            Seq("core.compile.super.run"),
+            Seq(
+              Seq(
+                None -> Seq(Label("core"), Label("compile.super"), Label("run"))
+              ) -> Seq.empty
+            )
+          )
+        }
+        
+        test("withArgs") {
+          check(
+            Seq("core.compile.super", "arg1", "arg2"),
+            Seq(
+              Seq(
+                None -> Seq(Label("core"), Label("compile.super"))
+              ) -> Seq("arg1", "arg2")
+            )
+          )
+        }
+
+        test("withQualifiedClass") {
+          check(
+            Seq("core.compile.super.qux.Baz"),
+            Seq(
+              Seq(
+                None -> Seq(Label("core"), Label("compile.super"), Label("qux"), Label("Baz"))
+              ) -> Seq.empty
+            )
+          )
+        }
+
+        test("withQualifiedClassAndArgs") {
+          check(
+            Seq("core.compile.super.qux.Baz", "arg1", "arg2"),
+            Seq(
+              Seq(
+                None -> Seq(Label("core"), Label("compile.super"), Label("qux"), Label("Baz"))
+              ) -> Seq("arg1", "arg2")
+            )
+          )
+        }
+        
+        test("withMultipleQualifiedSegments") {
+          check(
+            Seq("foo.bar.super.module.trait.Class"),
+            Seq(
+              Seq(
+                None -> Seq(Label("foo"), Label("bar.super"), Label("module"), Label("trait"), Label("Class"))
+              ) -> Seq.empty
+            )
+          )
+        }
+      }
     }
 
+    test("extractSegments") {
+      test("superTasks") {
+        test("basic") {
+          val result = ParseArgs.extractSegments("core.compile.super")
+          val expected = Result.Success(
+            (None, Some(Segments(Seq(Label("core"), Label("compile.super")))))
+          )
+          assert(result == expected)
+        }
+
+        test("withAdditionalPath") {
+          val result = ParseArgs.extractSegments("core.compile.super.run")
+          val expected = Result.Success(
+            (None, Some(Segments(Seq(Label("core"), Label("compile.super"), Label("run")))))
+          )
+          assert(result == expected)
+        }
+
+        test("withCrossSegment") {
+          val result = ParseArgs.extractSegments("bridges[2.12.4,jvm].compile.super")
+          val expected = Result.Success(
+            (None, Some(Segments(Seq(Label("bridges"), Cross(Seq("2.12.4", "jvm")), Label("compile.super")))))
+          )
+          assert(result == expected)
+        }
+
+        test("withQualifiedClass") {
+          val result = ParseArgs.extractSegments("core.compile.super.qux.Baz")
+          val expected = Result.Success(
+            (None, Some(Segments(Seq(Label("core"), Label("compile.super"), Label("qux"), Label("Baz")))))
+          )
+          assert(result == expected)
+        }
+
+        test("withComplexQualifiedClass") {
+          val result = ParseArgs.extractSegments("foo.bar.super.module.trait.Class")
+          val expected = Result.Success(
+            (None, Some(Segments(Seq(Label("foo"), Label("bar.super"), Label("module"), Label("trait"), Label("Class")))))
+          )
+          assert(result == expected)
+        }
+      }
+    }
   }
 }

--- a/core/resolve/test/src/mill/resolve/ResolveTests.scala
+++ b/core/resolve/test/src/mill/resolve/ResolveTests.scala
@@ -26,18 +26,18 @@ object ResolveTests extends TestSuite {
     def baseTask = Task { "base" }
     def multiOverride = Task { "base-multi" }
   }
-  
+
   object singleOverrideModule extends BaseModule {
     // Single override of baseTask
     override def baseTask = Task { "single-override" }
     lazy val millDiscover = Discover[this.type]
   }
-  
+
   trait MidModule extends BaseModule {
     // First level override of multiOverride
     override def multiOverride = Task { "mid-override" }
   }
-  
+
   object multiOverrideModule extends MidModule {
     // Second level override of multiOverride
     override def multiOverride = Task { "final-override" }
@@ -276,43 +276,43 @@ object ResolveTests extends TestSuite {
     test("supertasks") {
       test("singleOverride") {
         val check = new Checker(singleOverrideModule)
-        
+
         // Regular task should resolve to the overridden implementation
         test("regularTask") - check(
-          "baseTask", 
-          Result.Success(Set(_.baseTask)), 
+          "baseTask",
+          Result.Success(Set(_.baseTask)),
           Set("baseTask")
         )
-        
+
         // Super task should resolve to the base implementation
         test("superTask") - check(
-          "baseTask.super", 
-          Result.Success(Set(_.baseTask)), 
+          "baseTask.super",
+          Result.Success(Set(_.baseTask)),
           Set("baseTask.super")
         )
       }
-      
+
       test("multiOverride") {
         val check = new Checker(multiOverrideModule)
-        
+
         // Regular task should resolve to the final overridden implementation
         test("regularTask") - check(
-          "multiOverride", 
-          Result.Success(Set(_.multiOverride)), 
+          "multiOverride",
+          Result.Success(Set(_.multiOverride)),
           Set("multiOverride")
         )
-        
+
         // Direct super task should resolve to the mid-level implementation
         test("directSuperTask") - check(
-          "multiOverride.super", 
-          Result.Success(Set(_.multiOverride)), 
+          "multiOverride.super",
+          Result.Success(Set(_.multiOverride)),
           Set("multiOverride.super")
         )
-        
+
         // Qualified super task should resolve to the base implementation
         test("qualifiedSuperTask") - check(
-          "multiOverride.super.BaseModule", 
-          Result.Success(Set(_.multiOverride)), 
+          "multiOverride.super.BaseModule",
+          Result.Success(Set(_.multiOverride)),
           Set("multiOverride.super.BaseModule")
         )
       }

--- a/core/resolve/test/src/mill/resolve/ResolveTests.scala
+++ b/core/resolve/test/src/mill/resolve/ResolveTests.scala
@@ -21,6 +21,29 @@ object ResolveTests extends TestSuite {
     lazy val millDiscover = Discover[this.type]
   }
 
+  // Test modules for supertask resolution
+  trait BaseModule extends TestBaseModule {
+    def baseTask = Task { "base" }
+    def multiOverride = Task { "base-multi" }
+  }
+  
+  object singleOverrideModule extends BaseModule {
+    // Single override of baseTask
+    override def baseTask = Task { "single-override" }
+    lazy val millDiscover = Discover[this.type]
+  }
+  
+  trait MidModule extends BaseModule {
+    // First level override of multiOverride
+    override def multiOverride = Task { "mid-override" }
+  }
+  
+  object multiOverrideModule extends MidModule {
+    // Second level override of multiOverride
+    override def multiOverride = Task { "final-override" }
+    lazy val millDiscover = Discover[this.type]
+  }
+
   def isShortError(x: Result[?], s: String) =
     x.errorOpt.exists(_.contains(s)) &&
       // Make sure the stack traces are truncated and short-ish, and do not
@@ -250,5 +273,49 @@ object ResolveTests extends TestSuite {
       )
     }
 
+    test("supertasks") {
+      test("singleOverride") {
+        val check = new Checker(singleOverrideModule)
+        
+        // Regular task should resolve to the overridden implementation
+        test("regularTask") - check(
+          "baseTask", 
+          Result.Success(Set(_.baseTask)), 
+          Set("baseTask")
+        )
+        
+        // Super task should resolve to the base implementation
+        test("superTask") - check(
+          "baseTask.super", 
+          Result.Success(Set(_.baseTask)), 
+          Set("baseTask.super")
+        )
+      }
+      
+      test("multiOverride") {
+        val check = new Checker(multiOverrideModule)
+        
+        // Regular task should resolve to the final overridden implementation
+        test("regularTask") - check(
+          "multiOverride", 
+          Result.Success(Set(_.multiOverride)), 
+          Set("multiOverride")
+        )
+        
+        // Direct super task should resolve to the mid-level implementation
+        test("directSuperTask") - check(
+          "multiOverride.super", 
+          Result.Success(Set(_.multiOverride)), 
+          Set("multiOverride.super")
+        )
+        
+        // Qualified super task should resolve to the base implementation
+        test("qualifiedSuperTask") - check(
+          "multiOverride.super.BaseModule", 
+          Result.Success(Set(_.multiOverride)), 
+          Set("multiOverride.super.BaseModule")
+        )
+      }
+    }
   }
 }


### PR DESCRIPTION
Enhance `ParseArgs` to handle `.super` suffix in task selectors:
- Implement `processSuperSuffix` method to modify segments with `.super`
- Update `extractSegments` to post-process selector segments
- Add comprehensive test cases for various `.super` task resolution scenarios

Please open all PRs as drafts and ensure that your fork of Mill has 
`settings/actions` / `Allow all actions and reusable workflows` enabled to run CI on
your own fork of the Mill repo. Only once CI passes mark the PR as `Ready for review`
and CI will run on the main Mill repo before we merge it.
