### PR TITLE
Change `os.Path` targets to `PathRef` in scalanativelib (com-lihaoyi#…

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -158,7 +158,7 @@ object Deps {
   val junitInterface = ivy"com.github.sbt:junit-interface:0.13.3"
   val commonsIo = ivy"commons-io:commons-io:2.18.0"
   val log4j2Core = ivy"org.apache.logging.log4j:log4j-core:2.24.3"
-  val osLib = ivy"com.lihaoyi::os-lib:0.11.5-M1"
+  val osLib = ivy"com.lihaoyi::os-lib:0.11.5-M2"
   val pprint = ivy"com.lihaoyi::pprint:0.9.0"
   val mainargs = ivy"com.lihaoyi::mainargs:0.7.6"
   val millModuledefsVersion = "0.11.3-M4"

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -244,8 +244,8 @@ class BloopImpl(evs: () => Seq[Evaluator], wd: os.Path) extends ExternalModule {
               },
               gc = m.nativeGC(),
               targetTriple = m.nativeTarget(),
-              clang = m.nativeClang().toNIO,
-              clangpp = m.nativeClangPP().toNIO,
+              clang = m.nativeClang().path.toNIO,
+              clangpp = m.nativeClangPP().path.toNIO,
               options = Config.NativeOptions(
                 m.nativeLinkingOptions().toList,
                 m.nativeCompileOptions().toList

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -258,7 +258,7 @@ object BloopTests extends TestSuite {
             assert(sources == List(workdir / "scalanativeModule/src"))
             assert(version == build.scalanativeModule.sv)
             assert(platform.config.mode == BloopConfig.LinkerMode.Debug)
-            assert(platform.config.clang == clang.value.toNIO)
+            assert(platform.config.clang == clang.value.path.toNIO)
         }
       }
       test("skipped") {

--- a/core/exec/src/mill/exec/Execution.scala
+++ b/core/exec/src/mill/exec/Execution.scala
@@ -184,6 +184,7 @@ private[mill] case class Execution(
                   zincProblemReporter = reporter,
                   testReporter = testReporter,
                   logger = contextLogger,
+                  deps = deps,
                   classToTransitiveClasses,
                   allTransitiveClassMethods,
                   forkExecutionContext,

--- a/core/exec/src/mill/exec/GroupExecution.scala
+++ b/core/exec/src/mill/exec/GroupExecution.scala
@@ -48,6 +48,7 @@ private trait GroupExecution {
       zincProblemReporter: Int => Option[CompileProblemReporter],
       testReporter: TestReporter,
       logger: ColorLogger,
+      deps: Seq[Task[?]],
       classToTransitiveClasses: Map[Class[?], IndexedSeq[Class[?]]],
       allTransitiveClassMethods: Map[Class[?], Map[String, Method]],
       executionContext: mill.api.Ctx.Fork.Api,
@@ -127,7 +128,9 @@ private trait GroupExecution {
                   testReporter,
                   logger,
                   executionContext,
-                  exclusive
+                  exclusive,
+                  labelled.isInstanceOf[Command[?]],
+                  deps
                 )
 
               val valueHash = newResults(labelled) match {
@@ -166,7 +169,9 @@ private trait GroupExecution {
             testReporter,
             logger,
             executionContext,
-            exclusive
+            exclusive,
+            task.isInstanceOf[Command[?]],
+            deps
           )
           GroupExecution.Results(
             newResults,
@@ -192,7 +197,9 @@ private trait GroupExecution {
       testReporter: TestReporter,
       logger: mill.api.Logger,
       executionContext: mill.api.Ctx.Fork.Api,
-      exclusive: Boolean
+      exclusive: Boolean,
+      isCommand: Boolean,
+      deps: Seq[Task[?]]
   ): (Map[Task[?], ExecResult[(Val, Int)]], mutable.Buffer[Task[?]]) = {
 
     val newEvaluated = mutable.Buffer.empty[Task[?]]
@@ -235,20 +242,40 @@ private trait GroupExecution {
           ) with mill.api.Ctx.Jobs {
             override def jobs: Int = effectiveThreadCount
           }
+          // Tasks must be allowed to write to upstream worker's dest folders, because
+          // the point of workers is to manualy manage long-lived state which includes
+          // state on disk.
+          val validDests =
+            deps.collect { case n: Worker[?] =>
+              ExecutionPaths.resolve(outPath, n.ctx.segments).dest
+            } ++
+              paths.map(_.dest)
 
+          val executionChecker = new os.Checker {
+            def onRead(path: os.ReadablePath): Unit = ()
+            def onWrite(path: os.Path): Unit = {
+              if (!isCommand) {
+                if (path.startsWith(workspace) && !validDests.exists(path.startsWith(_))) {
+                  sys.error(s"Writing to $path not allowed during execution phase")
+                }
+              }
+            }
+          }
           def wrap[T](t: => T): T = {
             val (streams, destFunc) =
               if (exclusive) (exclusiveSystemStreams, () => workspace)
               else (multiLogger.systemStreams, () => makeDest())
 
             os.dynamicPwdFunction.withValue(destFunc) {
-              SystemStreams.withStreams(streams) {
-                val exposedEvaluator = if (!exclusive) null else getEvaluator()
-                Evaluator.currentEvaluator0.withValue(exposedEvaluator) {
-                  if (!exclusive) t
-                  else {
-                    logger.reportKey(Seq(counterMsg))
-                    logger.withPromptPaused { t }
+              os.checker.withValue(executionChecker) {
+                SystemStreams.withStreams(streams) {
+                  val exposedEvaluator = if (!exclusive) null else getEvaluator()
+                  Evaluator.currentEvaluator0.withValue(exposedEvaluator) {
+                    if (!exclusive) t
+                    else {
+                      logger.reportKey(Seq(counterMsg))
+                      logger.withPromptPaused { t }
+                    }
                   }
                 }
               }

--- a/core/internal/src/mill/internal/FileLogger.scala
+++ b/core/internal/src/mill/internal/FileLogger.scala
@@ -26,7 +26,7 @@ private[mill] class FileLogger(
     var folderCreated = false
     // Lazily create the folder and file that we're logging to, so as to avoid spamming the out/
     // folder with empty folders/files for the vast majority of tasks that do not have any logs
-    lazy val inner = {
+    lazy val inner = os.checker.withValue(os.Checker.Nop) {
       if (!os.exists(file / os.up)) os.makeDir.all(file / os.up)
       folderCreated = true
       Files.newOutputStream(file.toNIO, options*)

--- a/core/resolve/src/mill/resolve/Resolve.scala
+++ b/core/resolve/src/mill/resolve/Resolve.scala
@@ -8,6 +8,7 @@ import mill.define.{
   Discover,
   Module,
   NamedTask,
+  Segment,
   Segments,
   TaskModule,
   SelectMode
@@ -27,7 +28,10 @@ private[mill] object Resolve {
         resolveToModuleTasks: Boolean,
         cache: ResolveCore.Cache
     ) = {
-      Result.Success(resolved.map(_.segments))
+      // For qualified super tasks (super.Something), return the original selector
+      // Otherwise, return the resolved segments
+      val hasQualifiedSuper = selector.render.contains(".super.")
+      Result.Success(if (hasQualifiedSuper) Seq(selector) else resolved.map(_.segments))
     }
 
     private[mill] override def deduplicate(items: List[Segments]): List[Segments] = items.distinct
@@ -58,10 +62,33 @@ private[mill] object Resolve {
 
       val taskList: Seq[Result[Option[NamedTask[?]]]] = resolved.map {
         case r: Resolved.NamedTask =>
-          val instantiated = ResolveCore
-            .instantiateModule(rootModule, r.segments.init, cache)
-            .flatMap(instantiateNamedTask(r, _, cache))
-          instantiated.map(Some(_))
+          val superIdx = r.segments.value.indexWhere {
+            case Segment.Label("super") => true
+            case _ => false
+          }
+          
+          if (superIdx >= 0) {
+            // For tasks with super, create a task with segments before the super segment
+            val segmentsWithoutSuper = mill.define.Segments(r.segments.value.take(superIdx))
+            Result.Success(Some(new NamedTask[Any] {
+              override def ctx0 = mill.define.Ctx.makeRoot(
+                millModuleEnclosing0 = rootModule.moduleCtx.enclosing,
+                millModuleLine0 = rootModule.moduleCtx.lineNum,
+                millSourcePath = rootModule.moduleCtx.millSourcePath,
+                segments0 = segmentsWithoutSuper,
+                external0 = rootModule.moduleCtx.external,
+                fileName = rootModule.moduleCtx.fileName
+              )
+              override def isPrivate = None
+              override val inputs = Nil
+              override def evaluate0 = ???
+            }))
+          } else {
+            val instantiated = ResolveCore
+              .instantiateModule(rootModule, r.segments.init, cache)
+              .flatMap(instantiateNamedTask(r, _, cache))
+            instantiated.map(Some(_))
+          }
 
         case r: Resolved.Command =>
           val instantiated = ResolveCore

--- a/core/resolve/src/mill/resolve/ResolveCore.scala
+++ b/core/resolve/src/mill/resolve/ResolveCore.scala
@@ -141,6 +141,9 @@ private object ResolveCore {
         }
 
         (head, current) match {
+          case (Segment.Label("super"), task: Resolved.NamedTask) =>
+            Success(Seq(Resolved.NamedTask(task.segments ++ Seq(head))))
+
           case (Segment.Label(singleLabel), m: Resolved.Module) =>
             val resOrErr: mill.api.Result[Seq[Resolved]] = singleLabel match {
               case "__" =>

--- a/core/src/mill/eval/EvaluatorImpl.scala
+++ b/core/src/mill/eval/EvaluatorImpl.scala
@@ -57,13 +57,15 @@ final class EvaluatorImpl private[mill] (
       allowPositionalCommandArgs: Boolean = false,
       resolveToModuleTasks: Boolean = false
   ): mill.api.Result[List[Segments]] = {
-    Resolve.Segments.resolve(
-      rootModule,
-      scriptArgs,
-      selectMode,
-      allowPositionalCommandArgs,
-      resolveToModuleTasks
-    )
+    os.checker.withValue(EvaluatorImpl.resolveChecker) {
+      Resolve.Segments.resolve(
+        rootModule,
+        scriptArgs,
+        selectMode,
+        allowPositionalCommandArgs,
+        resolveToModuleTasks
+      )
+    }
   }
 
   /**
@@ -76,14 +78,16 @@ final class EvaluatorImpl private[mill] (
       allowPositionalCommandArgs: Boolean = false,
       resolveToModuleTasks: Boolean = false
   ): mill.api.Result[List[NamedTask[?]]] = {
-    Evaluator.currentEvaluator0.withValue(this) {
-      Resolve.Tasks.resolve(
-        rootModule,
-        scriptArgs,
-        selectMode,
-        allowPositionalCommandArgs,
-        resolveToModuleTasks
-      )
+    os.checker.withValue(EvaluatorImpl.resolveChecker) {
+      Evaluator.currentEvaluator0.withValue(this) {
+        Resolve.Tasks.resolve(
+          rootModule,
+          scriptArgs,
+          selectMode,
+          allowPositionalCommandArgs,
+          resolveToModuleTasks
+        )
+      }
     }
   }
 
@@ -150,7 +154,7 @@ final class EvaluatorImpl private[mill] (
                 reporter = reporter,
                 testReporter = testReporter,
                 workspace = workspace,
-                systemExit = m => ???,
+                systemExit = _ => ???,
                 fork = null
               )
               val pretty = t.ctx0.fileName + ":" + t.ctx0.lineNum
@@ -207,13 +211,15 @@ final class EvaluatorImpl private[mill] (
       selectMode: SelectMode,
       selectiveExecution: Boolean = false
   ): mill.api.Result[Evaluator.Result[Any]] = {
-    val resolved = Evaluator.currentEvaluator0.withValue(this) {
-      Resolve.Tasks.resolve(
-        rootModule,
-        scriptArgs,
-        selectMode,
-        allowPositionalCommandArgs
-      )
+    val resolved = os.checker.withValue(EvaluatorImpl.resolveChecker) {
+      Evaluator.currentEvaluator0.withValue(this) {
+        Resolve.Tasks.resolve(
+          rootModule,
+          scriptArgs,
+          selectMode,
+          allowPositionalCommandArgs
+        )
+      }
     }
 
     for (targets <- resolved)
@@ -224,7 +230,13 @@ final class EvaluatorImpl private[mill] (
 
 }
 object EvaluatorImpl {
+  val resolveChecker = new os.Checker {
+    def onRead(path: os.ReadablePath): Unit = ()
 
+    def onWrite(path: os.Path): Unit = {
+      sys.error(s"Writing to $path not allowed during resolution phase")
+    }
+  }
   private[mill] def formatFailing(evaluated: ExecutionResults): String = {
     (for ((k, fs) <- evaluated.failing)
       yield {

--- a/example/thirdparty/acyclic/build.mill
+++ b/example/thirdparty/acyclic/build.mill
@@ -4,11 +4,13 @@ import mill._, scalalib._, publish._
 // acyclic test suite assumes files are on disk at specific paths relative to `os.pwd`.
 // To avoid changing the test code, we instead copy the necessary files into the `os.pwd`
 // when preparing the resources for test suite execution
-os.copy.over(
-  interp.watch(mill.api.WorkspaceRoot.workspaceRoot / "acyclic"),
-  os.pwd / "acyclic",
-  createFolders = true
-)
+os.checker.withValue(os.Checker.Nop) {
+  os.copy.over(
+    interp.watch(mill.api.WorkspaceRoot.workspaceRoot / "acyclic"),
+    os.pwd / "acyclic",
+    createFolders = true
+  )
+}
 
 object Deps {
   def acyclic = ivy"com.lihaoyi:::acyclic:0.3.6"

--- a/integration/failure/os-checker/resources/build.mill
+++ b/integration/failure/os-checker/resources/build.mill
@@ -1,0 +1,20 @@
+package build
+import mill._
+
+
+
+object foo extends Module{
+  os.write(moduleDir / "file.txt", "hello", createFolders = true)
+
+  def bar() = Task.Command{ println(31337) }
+}
+
+def qux = Task{
+  os.write(Task.workspace / "file.txt", "hello")
+}
+
+def baz = Task{1}
+
+if (false) {
+  os.write(moduleDir / "file.txt", "hello", createFolders = true)
+}

--- a/integration/failure/os-checker/src/OsCheckerTests.scala
+++ b/integration/failure/os-checker/src/OsCheckerTests.scala
@@ -1,0 +1,36 @@
+package mill.integration
+
+import mill.testkit.UtestIntegrationTestSuite
+
+import utest._
+
+object OsCheckerTests extends UtestIntegrationTestSuite {
+  val tests: Tests = Tests {
+    test - integrationTest { tester =>
+      import tester._
+      val res = tester.eval("foo.bar")
+
+      val sep = if (mill.constants.Util.isWindows) "\\" else "/"
+      assert(res.isSuccess == false)
+      assert(res.err.contains(
+        s"Writing to $workspacePath${sep}foo not allowed during resolution phase"
+      ))
+
+      val res2 = tester.eval("qux")
+
+      assert(res2.isSuccess == false)
+      assert(res2.err.contains(
+        s"Writing to $workspacePath${sep}file.txt not allowed during execution phase"
+      ))
+
+      tester.modifyFile(workspacePath / "build.mill", _.replace("if (false)", "if (true)"))
+      val res3 = tester.eval("baz")
+
+      assert(res3.isSuccess == false)
+      assert(res3.err.contains(
+        s"Writing to $workspacePath not allowed during resolution phase"
+      ))
+
+    }
+  }
+}

--- a/integration/feature/full-run-logs/src/FullRunLogsTests.scala
+++ b/integration/feature/full-run-logs/src/FullRunLogsTests.scala
@@ -74,5 +74,58 @@ object FullRunLogsTests extends UtestIntegrationTestSuite {
       assert(millProfile.exists(_.obj("label").str == "show"))
       assert(millChromeProfile.exists(_.obj("name").str == "show"))
     }
+    test("failedTasksCounter") - integrationTest { tester =>
+      import tester._
+
+      val javaSource = os.Path(workspacePath, os.pwd)
+      val fooJava = javaSource / "src" / "foo" / "Foo.java"
+      val originalContent = os.read(fooJava)
+
+      // Introduce a compilation error by adding an unclosed brace
+      modifyFile(fooJava, _.replace("class Foo", "class Foo {"))
+
+      // Run with ticker to see the failed tasks count for compile
+      val compileRes = eval(("--ticker", "true", "compile"))
+      compileRes.isSuccess ==> false
+
+      // Verify the output shows failed tasks count in the progress indicator
+      val failedPattern = "\\[(\\d+)/(\\d+),\\s*(\\d+)\\s*failed\\]".r // Matches [X/Y, N failed]
+      val failedMatch = failedPattern.findFirstIn(compileRes.err)
+      failedMatch.isDefined ==> true
+
+      // Extract and verify the number of failed tasks
+      val failedCount =
+        failedPattern.findFirstMatchIn(compileRes.err).map(_.group(3).toInt).getOrElse(0)
+      failedCount ==> 1 // Expecting 1 failed task for compile
+
+      // Run jar task with --keep-going to see upstream failures
+      val jarKeepGoingRes = eval(("--ticker", "true", "--keep-going", "jar"))
+      jarKeepGoingRes.isSuccess ==> false
+
+      // Verify the output shows failed tasks count in the progress indicator
+      val jarKeepGoingFailedMatch = failedPattern.findFirstIn(jarKeepGoingRes.err)
+      jarKeepGoingFailedMatch.isDefined ==> true
+
+      // Extract and verify the number of failed tasks
+      val jarKeepGoingFailedCount =
+        failedPattern.findFirstMatchIn(jarKeepGoingRes.err).map(_.group(3).toInt).getOrElse(0)
+      jarKeepGoingFailedCount ==> 1 // Expecting 1 failed task for jar with --keep-going
+
+      // Run jar task without --keep-going to see it fail immediately
+      val jarRes = eval(("--ticker", "true", "jar"))
+      jarRes.isSuccess ==> false
+
+      // Verify the output shows failed tasks count in the progress indicator
+      val jarFailedMatch = failedPattern.findFirstIn(jarRes.err)
+      jarFailedMatch.isDefined ==> true
+
+      // Extract and verify the number of failed tasks
+      val jarFailedCount =
+        failedPattern.findFirstMatchIn(jarRes.err).map(_.group(3).toInt).getOrElse(0)
+      jarFailedCount ==> 1 // Expecting 1 failed task for jar without --keep-going
+
+      // Restore the original content
+      modifyFile(fooJava, _ => originalContent)
+    }
   }
 }

--- a/integration/feature/output-directory/src/OutputDirectoryLockTests.scala
+++ b/integration/feature/output-directory/src/OutputDirectoryLockTests.scala
@@ -24,7 +24,12 @@ object OutputDirectoryLockTests extends UtestIntegrationTestSuite {
       val signalFile = workspacePath / "do-wait"
       // Kick off blocking task in background
       Future {
-        eval(("show", "blockWhileExists", "--path", signalFile), check = true)
+        eval(
+          ("show", "blockWhileExists", "--path", signalFile),
+          check = true,
+          stdout = os.Inherit,
+          stderr = os.Inherit
+        )
       }
 
       // Wait for blocking task to write signal file, to indicate it has begun

--- a/integration/invalidation/watch-source-input/resources/build.mill
+++ b/integration/invalidation/watch-source-input/resources/build.mill
@@ -33,10 +33,12 @@ def lol = Task {
 
 def writeCompletionMarker(name: String) = {
 
-  Range(0, 10)
-    .map(i => mill.api.WorkspaceRoot.workspaceRoot / "out" / s"$name$i")
-    .find(!os.exists(_))
-    .foreach(os.write(_, ""))
+  os.checker.withValue(os.Checker.Nop) {
+    Range(0, 10)
+      .map(i => mill.api.WorkspaceRoot.workspaceRoot / "out" / s"$name$i")
+      .find(!os.exists(_))
+      .foreach(os.write(_, ""))
+  }
 }
 
 writeCompletionMarker("initialized")

--- a/javascriptlib/src/mill/javascriptlib/PublishModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/PublishModule.scala
@@ -130,12 +130,11 @@ trait PublishModule extends TypeScriptModule {
   private def pubGenSources: T[Unit] = Task {
     val allGeneratedSources = pubBaseModeGenSources() ++ pubModDepsGenSources()
     allGeneratedSources.foreach { target =>
-      val destination = publishDir().path / "typescript/generatedSources" / target.path.last
-      os.makeDir.all(destination / os.up)
-      os.copy.over(
-        target.path,
-        destination
-      )
+      os.checker.withValue(os.Checker.Nop) {
+        val destination = publishDir().path / "typescript/generatedSources" / target.path.last
+        os.makeDir.all(destination / os.up)
+        os.copy.over(target.path, destination)
+      }
     }
   }
 
@@ -144,12 +143,10 @@ trait PublishModule extends TypeScriptModule {
 
     targets.foreach { target =>
       val destination = publishDir().path / "typescript" / target
-      os.makeDir.all(destination / os.up)
-      os.copy(
-        Task.workspace / target,
-        destination,
-        mergeFolders = true
-      )
+      os.checker.withValue(os.Checker.Nop) {
+        os.makeDir.all(destination / os.up)
+        os.copy(Task.workspace / target, destination, mergeFolders = true)
+      }
     }
   }
 
@@ -259,31 +256,35 @@ trait PublishModule extends TypeScriptModule {
 
   private def pubSymLink: Task[Unit] = Task {
     pubTsPatchInstall() // patch typescript compiler => use custom transformers
-    os.symlink(publishDir().path / "node_modules", npmInstall().path / "node_modules")
+    os.checker.withValue(os.Checker.Nop) {
+      os.symlink(publishDir().path / "node_modules", npmInstall().path / "node_modules")
 
-    if (os.exists(npmInstall().path / ".npmrc"))
-      os.symlink(publishDir().path / ".npmrc", npmInstall().path / ".npmrc")
+      if (os.exists(npmInstall().path / ".npmrc"))
+        os.symlink(publishDir().path / ".npmrc", npmInstall().path / ".npmrc")
+    }
   }
 
   override def compile: T[(PathRef, PathRef)] = Task {
     pubSymLink()
-    os.write(
-      publishDir().path / "tsconfig.json",
-      ujson.Obj(
-        "compilerOptions" -> ujson.Obj.from(
-          compilerOptionsBuilder().toSeq ++ Seq("typeRoots" -> typeRoots())
-        ),
-        "files" -> pubAllSources()
+    os.checker.withValue(os.Checker.Nop) {
+      os.write(
+        publishDir().path / "tsconfig.json",
+        ujson.Obj(
+          "compilerOptions" -> ujson.Obj.from(
+            compilerOptionsBuilder().toSeq ++ Seq("typeRoots" -> typeRoots())
+          ),
+          "files" -> pubAllSources()
+        )
       )
-    )
-    os.copy(moduleDir, publishDir().path / "typescript", mergeFolders = true)
-    pubCopyModDeps()
-    pubGenSources()
-    // Run type check, build declarations
-    os.call(
-      ("node", npmInstall().path / "node_modules/typescript/bin/tsc"),
-      cwd = publishDir().path
-    )
+      os.copy(moduleDir, publishDir().path / "typescript", mergeFolders = true)
+      pubCopyModDeps()
+      pubGenSources()
+      // Run type check, build declarations
+      os.call(
+        ("node", npmInstall().path / "node_modules/typescript/bin/tsc"),
+        cwd = publishDir().path
+      )
+    }
     (publishDir(), PathRef(publishDir().path / "typescript"))
   }
 

--- a/javascriptlib/src/mill/javascriptlib/TestModule.scala
+++ b/javascriptlib/src/mill/javascriptlib/TestModule.scala
@@ -41,10 +41,12 @@ object TestModule {
     // <rootDir> = '/out'; allow coverage resolve distributed source files.
     // & define coverage files relative to <rootDir>.
     private[TestModule] def coverageSetupSymlinks: Task[Unit] = Task.Anon {
-      os.symlink(Task.workspace / "out/node_modules", npmInstall().path / "node_modules")
-      os.symlink(Task.workspace / "out/tsconfig.json", compile()._1.path / "tsconfig.json")
-      if (os.exists(compile()._1.path / ".nycrc"))
-        os.symlink(Task.workspace / "out/.nycrc", compile()._1.path / ".nycrc")
+      os.checker.withValue(os.Checker.Nop) {
+        os.symlink(Task.workspace / "out/node_modules", npmInstall().path / "node_modules")
+        os.symlink(Task.workspace / "out/tsconfig.json", compile()._1.path / "tsconfig.json")
+        if (os.exists(compile()._1.path / ".nycrc"))
+          os.symlink(Task.workspace / "out/.nycrc", compile()._1.path / ".nycrc")
+      }
     }
 
     def istanbulNycrcConfigBuilder: Task[PathRef] = Task.Anon {
@@ -65,11 +67,12 @@ object TestModule {
             |}
             |""".stripMargin
 
-      if (!os.exists(customConfig)) os.write.over(config, content)
-      else os.copy.over(customConfig, config)
+      os.checker.withValue(os.Checker.Nop) {
+        if (!os.exists(customConfig)) os.write.over(config, content)
+        else os.copy.over(customConfig, config)
 
-      os.write.over(config, content)
-
+        os.write.over(config, content)
+      }
       PathRef(config)
     }
 
@@ -161,8 +164,10 @@ object TestModule {
             |}
             |""".stripMargin
 
-      if (!os.exists(customConfig)) os.write.over(config, content)
-      else os.copy.over(customConfig, config)
+      os.checker.withValue(os.Checker.Nop) {
+        if (!os.exists(customConfig)) os.write.over(config, content)
+        else os.copy.over(customConfig, config)
+      }
 
       PathRef(config)
     }
@@ -230,31 +235,35 @@ object TestModule {
             |}
             |""".stripMargin
 
-      if (!os.exists(customConfig)) os.write.over(config, content)
-      else os.copy.over(customConfig, config)
+      os.checker.withValue(os.Checker.Nop) {
+        if (!os.exists(customConfig)) os.write.over(config, content)
+        else os.copy.over(customConfig, config)
+      }
 
       PathRef(config)
     }
 
     def runCoverage: T[TestResult] = Task {
       coverageSetupSymlinks()
-      os.call(
-        (
-          "node",
-          "node_modules/jest/bin/jest.js",
-          "--config",
-          coverageConf().path,
-          "--coverage",
-          getPathToTest()
-        ),
-        stdout = os.Inherit,
-        env = forkEnv(),
-        cwd = Task.workspace / "out"
-      )
+      os.checker.withValue(os.Checker.Nop) {
+        os.call(
+          (
+            "node",
+            "node_modules/jest/bin/jest.js",
+            "--config",
+            coverageConf().path,
+            "--coverage",
+            getPathToTest()
+          ),
+          stdout = os.Inherit,
+          env = forkEnv(),
+          cwd = Task.workspace / "out"
+        )
 
-      // remove symlink
-      os.remove(Task.workspace / "out/node_modules")
-      os.remove(Task.workspace / "out/tsconfig.json")
+        // remove symlink
+        os.remove(Task.workspace / "out/node_modules")
+        os.remove(Task.workspace / "out/tsconfig.json")
+      }
       ()
     }
 
@@ -287,8 +296,9 @@ object TestModule {
            |require('mocha/bin/_mocha');
            |""".stripMargin
 
-      os.write.over(runner, content)
-
+      os.checker.withValue(os.Checker.Nop) {
+        os.write.over(runner, content)
+      }
       PathRef(runner)
     }
 
@@ -327,9 +337,11 @@ object TestModule {
       )
 
       // remove symlink
-      os.remove(Task.workspace / "out/node_modules")
-      os.remove(Task.workspace / "out/tsconfig.json")
-      os.remove(Task.workspace / "out/.nycrc")
+      os.checker.withValue(os.Checker.Nop) {
+        os.remove(Task.workspace / "out/node_modules")
+        os.remove(Task.workspace / "out/tsconfig.json")
+        os.remove(Task.workspace / "out/.nycrc")
+      }
       ()
     }
   }
@@ -379,9 +391,10 @@ object TestModule {
            |});
            |""".stripMargin
 
-      if (!os.exists(customConfig)) os.write.over(config, content)
-      else os.copy.over(customConfig, config)
-
+      os.checker.withValue(os.Checker.Nop) {
+        if (!os.exists(customConfig)) os.write.over(config, content)
+        else os.copy.over(customConfig, config)
+      }
       PathRef(config)
     }
 
@@ -438,9 +451,10 @@ object TestModule {
             |});
             |""".stripMargin
 
-      if (!os.exists(customConfig)) os.write.over(config, content)
-      else os.copy.over(customConfig, config)
-
+      os.checker.withValue(os.Checker.Nop) {
+        if (!os.exists(customConfig)) os.write.over(config, content)
+        else os.copy.over(customConfig, config)
+      }
       PathRef(config)
     }
 
@@ -461,8 +475,10 @@ object TestModule {
         cwd = Task.workspace / "out"
       )
       // remove symlink
-      os.remove(Task.workspace / "out/node_modules")
-      os.remove(Task.workspace / "out/tsconfig.json")
+      os.checker.withValue(os.Checker.Nop) {
+        os.remove(Task.workspace / "out/node_modules")
+        os.remove(Task.workspace / "out/tsconfig.json")
+      }
       ()
     }
 
@@ -492,18 +508,20 @@ object TestModule {
 
     def conf: Task[PathRef] = Task.Anon {
       val path = compile()._1.path / "jasmine.json"
-      os.write.over(
-        path,
-        ujson.write(
-          ujson.Obj(
-            "spec_dir" -> ujson.Str("typescript/src"),
-            "spec_files" -> ujson.Arr(ujson.Str("**/*.test.ts")),
-            "stopSpecOnExpectationFailure" -> ujson.Bool(false),
-            "random" -> ujson.Bool(false)
+      os.checker.withValue(os.Checker.Nop) {
+        os.write.over(
+          path,
+          ujson.write(
+            ujson.Obj(
+              "spec_dir" -> ujson.Str("typescript/src"),
+              "spec_files" -> ujson.Arr(ujson.Str("**/*.test.ts")),
+              "stopSpecOnExpectationFailure" -> ujson.Bool(false),
+              "random" -> ujson.Bool(false)
+            )
           )
         )
-      )
 
+      }
       PathRef(path)
     }
 
@@ -512,18 +530,20 @@ object TestModule {
       val jasmine = "node_modules/jasmine/bin/jasmine.js"
       val tsnode = "node_modules/ts-node/register/transpile-only.js"
       val tsconfigPath = "node_modules/tsconfig-paths/register.js"
-      os.call(
-        (
-          "node",
-          jasmine,
-          "--config=jasmine.json",
-          s"--require=$tsnode",
-          s"--require=$tsconfigPath"
-        ),
-        stdout = os.Inherit,
-        env = forkEnv(),
-        cwd = compile()._1.path
-      )
+      os.checker.withValue(os.Checker.Nop) {
+        os.call(
+          (
+            "node",
+            jasmine,
+            "--config=jasmine.json",
+            s"--require=$tsnode",
+            s"--require=$tsconfigPath"
+          ),
+          stdout = os.Inherit,
+          env = forkEnv(),
+          cwd = compile()._1.path
+        )
+      }
       ()
     }
 
@@ -535,46 +555,50 @@ object TestModule {
     def coverageConf: T[PathRef] = Task {
       val path = compile()._1.path / "jasmine.json"
       val specDir = compile()._2.path.subRelativeTo(Task.workspace / "out") / "src"
-      os.write.over(
-        path,
-        ujson.write(
-          ujson.Obj(
-            "spec_dir" -> ujson.Str(specDir.toString),
-            "spec_files" -> ujson.Arr(ujson.Str("**/*.test.ts")),
-            "stopSpecOnExpectationFailure" -> ujson.Bool(false),
-            "random" -> ujson.Bool(false)
+      os.checker.withValue(os.Checker.Nop) {
+        os.write.over(
+          path,
+          ujson.write(
+            ujson.Obj(
+              "spec_dir" -> ujson.Str(specDir.toString),
+              "spec_files" -> ujson.Arr(ujson.Str("**/*.test.ts")),
+              "stopSpecOnExpectationFailure" -> ujson.Bool(false),
+              "random" -> ujson.Bool(false)
+            )
           )
         )
-      )
+      }
       PathRef(path)
     }
 
     def runCoverage: T[TestResult] = Task {
-      istanbulNycrcConfigBuilder()
-      coverageSetupSymlinks()
-      val jasmine = "node_modules/jasmine/bin/jasmine.js"
-      val tsnode = "node_modules/ts-node/register/transpile-only.js"
-      val tsconfigPath = "node_modules/tsconfig-paths/register.js"
-      val relConfigPath = coverageConf().path.subRelativeTo(Task.workspace / "out")
-      os.call(
-        (
-          "./node_modules/.bin/nyc",
-          "node",
-          jasmine,
-          s"--config=$relConfigPath",
-          s"--require=$tsnode",
-          s"--require=$tsconfigPath"
-        ),
-        stdout = os.Inherit,
-        env = forkEnv(),
-        cwd = Task.workspace / "out"
-      )
+      os.checker.withValue(os.Checker.Nop) {
+        istanbulNycrcConfigBuilder()
+        coverageSetupSymlinks()
+        val jasmine = "node_modules/jasmine/bin/jasmine.js"
+        val tsnode = "node_modules/ts-node/register/transpile-only.js"
+        val tsconfigPath = "node_modules/tsconfig-paths/register.js"
+        val relConfigPath = coverageConf().path.subRelativeTo(Task.workspace / "out")
+        os.call(
+          (
+            "./node_modules/.bin/nyc",
+            "node",
+            jasmine,
+            s"--config=$relConfigPath",
+            s"--require=$tsnode",
+            s"--require=$tsconfigPath"
+          ),
+          stdout = os.Inherit,
+          env = forkEnv(),
+          cwd = Task.workspace / "out"
+        )
 
-      // remove symlink
-      os.remove(Task.workspace / "out/node_modules")
-      os.remove(Task.workspace / "out/tsconfig.json")
-      os.remove(Task.workspace / "out/.nycrc")
-      ()
+        // remove symlink
+        os.remove(Task.workspace / "out/node_modules")
+        os.remove(Task.workspace / "out/tsconfig.json")
+        os.remove(Task.workspace / "out/.nycrc")
+        ()
+      }
     }
 
   }
@@ -673,10 +697,12 @@ object TestModule {
       Task.Source(Task.workspace / "playwright.config.ts")
 
     private def copyConfig: Task[TestResult] = Task.Anon {
-      os.copy.over(
-        testConfigSource().path,
-        compile()._1.path / "playwright.config.ts"
-      )
+      os.checker.withValue(os.Checker.Nop) {
+        os.copy.over(
+          testConfigSource().path,
+          compile()._1.path / "playwright.config.ts"
+        )
+      }
     }
 
     private def runTest: T[TestResult] = Task {

--- a/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/kover/KoverModule.scala
@@ -103,8 +103,9 @@ trait KoverModule extends KotlinModule { outer =>
     override def forkArgs: T[Seq[String]] = Task {
       val argsFile = koverDataDir().path / "kover-agent.args"
       val content = s"report.file=${koverBinaryReport().path}"
-      os.write.over(argsFile, content)
-
+      os.checker.withValue(os.Checker.Nop) {
+        os.write.over(argsFile, content)
+      }
       super.forkArgs() ++
         Seq(
           s"-javaagent:${koverAgentJar().path}=file:$argsFile"

--- a/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
+++ b/kotlinlib/src/mill/kotlinlib/ktlint/KtlintModule.scala
@@ -122,15 +122,17 @@ object KtlintModule extends ExternalModule with KtlintModule with TaskModule {
       .filter(f => os.exists(f) && (f.ext == "kt" || f.ext == "kts"))
       .map(_.toString())
 
-    val exitCode = Jvm.callProcess(
-      mainClass = "com.pinterest.ktlint.Main",
-      classPath = classPath.map(_.path).toVector,
-      mainArgs = args.result(),
-      cwd = moduleDir,
-      stdin = os.Inherit,
-      stdout = os.Inherit,
-      check = false
-    ).exitCode
+    val exitCode = os.checker.withValue(os.Checker.Nop) {
+      Jvm.callProcess(
+        mainClass = "com.pinterest.ktlint.Main",
+        classPath = classPath.map(_.path).toVector,
+        mainArgs = args.result(),
+        cwd = moduleDir,
+        stdin = os.Inherit,
+        stdout = os.Inherit,
+        check = false
+      ).exitCode
+    }
 
     if (exitCode == 0) {} // do nothing
     else {

--- a/main/init/src/mill/init/BuildGenModule.scala
+++ b/main/init/src/mill/init/BuildGenModule.scala
@@ -22,7 +22,7 @@ trait BuildGenModule extends TaskModule {
 
   def buildGenScalafmtConfig: T[PathRef] = PathRef(BuildGenUtil.scalafmtConfigFile)
 
-  def init(args: String*): Command[Unit] = Task.Command {
+  def init(args: String*): Command[Unit] = Task.Command(exclusive = true) {
     val root = moduleDir
 
     val mainClass = buildGenMainClass()

--- a/pythonlib/src/mill/pythonlib/PythonModule.scala
+++ b/pythonlib/src/mill/pythonlib/PythonModule.scala
@@ -176,29 +176,31 @@ trait PythonModule extends PipModule with TaskModule { outer =>
     val (procUuidPath, procLockfile, procUuid) = mill.scalalib.RunModule.backgroundSetup(Task.dest)
     val pwd0 = os.Path(java.nio.file.Paths.get(".").toAbsolutePath)
 
-    Jvm.spawnProcess(
-      mainClass = "mill.scalalib.backgroundwrapper.MillBackgroundWrapper",
-      classPath = mill.scalalib.ZincWorkerModule.backgroundWrapperClasspath().map(_.path).toSeq,
-      jvmArgs = Nil,
-      env = runnerEnvTask(),
-      mainArgs = Seq(
-        procUuidPath.toString,
-        procLockfile.toString,
-        procUuid,
-        "500",
-        "<subprocess>",
-        pythonExe().path.toString,
-        mainScript().path.toString
-      ) ++ args.value,
-      cwd = Task.workspace,
-      stdin = "",
-      // Hack to forward the background subprocess output to the Mill server process
-      // stdout/stderr files, so the output will get properly slurped up by the Mill server
-      // and shown to any connected Mill client even if the current command has completed
-      stdout = os.PathAppendRedirect(pwd0 / ".." / ServerFiles.stdout),
-      stderr = os.PathAppendRedirect(pwd0 / ".." / ServerFiles.stderr),
-      javaHome = mill.scalalib.ZincWorkerModule.javaHome().map(_.path)
-    )
+    os.checker.withValue(os.Checker.Nop) {
+      Jvm.spawnProcess(
+        mainClass = "mill.scalalib.backgroundwrapper.MillBackgroundWrapper",
+        classPath = mill.scalalib.ZincWorkerModule.backgroundWrapperClasspath().map(_.path).toSeq,
+        jvmArgs = Nil,
+        env = runnerEnvTask(),
+        mainArgs = Seq(
+          procUuidPath.toString,
+          procLockfile.toString,
+          procUuid,
+          "500",
+          "<subprocess>",
+          pythonExe().path.toString,
+          mainScript().path.toString
+        ) ++ args.value,
+        cwd = Task.workspace,
+        stdin = "",
+        // Hack to forward the background subprocess output to the Mill server process
+        // stdout/stderr files, so the output will get properly slurped up by the Mill server
+        // and shown to any connected Mill client even if the current command has completed
+        stdout = os.PathAppendRedirect(pwd0 / ".." / ServerFiles.stdout),
+        stderr = os.PathAppendRedirect(pwd0 / ".." / ServerFiles.stderr),
+        javaHome = mill.scalalib.ZincWorkerModule.javaHome().map(_.path)
+      )
+    }
     ()
   }
 

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -178,7 +178,6 @@ class MillBuildBootstrap(
           }
         }
 
-        mill.constants.DebugLog.println("rootModuleRes")
         val rootModuleRes = nestedState.frames.headOption match {
           case None => Result.Success(nestedState.bootstrapModuleOpt.get)
           case Some(nestedFrame) =>

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -164,7 +164,6 @@ class MillBuildBootstrap(
       } else {
 
         def renderFailure(e: Throwable): String = {
-          mill.constants.DebugLog.println("renderFailure " + e)
           e match {
             case e: ExceptionInInitializerError if e.getCause != null => renderFailure(e.getCause)
             case e: NoClassDefFoundError if e.getCause != null => renderFailure(e.getCause)

--- a/runner/src/mill/runner/MillBuildBootstrap.scala
+++ b/runner/src/mill/runner/MillBuildBootstrap.scala
@@ -8,11 +8,12 @@ import mill.api.{ColorLogger, PathRef, Result, SystemStreams, Val, WorkspaceRoot
 import mill.define.{BaseModule, Evaluator, Segments, SelectMode}
 import mill.exec.JsonArrayLogger
 import mill.constants.OutFiles.{millBuild, millChromeProfile, millProfile, millRunnerState}
+import mill.eval.EvaluatorImpl
 import mill.runner.worker.api.MillScalaParser
 import mill.runner.worker.ScalaCompilerWorker
+
 import java.io.File
 import java.net.URLClassLoader
-
 import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.util.Using
 
@@ -161,46 +162,72 @@ class MillBuildBootstrap(
         )
         nestedState.add(frame = evalState, errorOpt = None)
       } else {
-        val rootModule = nestedState.frames.headOption match {
-          case None => nestedState.bootstrapModuleOpt.get
-          case Some(nestedFrame) => getRootModule(nestedFrame.classLoaderOpt.get)
+
+        def renderFailure(e: Throwable): String = {
+          mill.constants.DebugLog.println("renderFailure " + e)
+          e match {
+            case e: ExceptionInInitializerError if e.getCause != null => renderFailure(e.getCause)
+            case e: NoClassDefFoundError if e.getCause != null => renderFailure(e.getCause)
+            case _ =>
+              val msg =
+                e.toString +
+                  "\n" +
+                  e.getStackTrace.dropRight(new Exception().getStackTrace.length).mkString("\n")
+
+              msg
+          }
         }
 
-        Using.resource(makeEvaluator(
-          prevFrameOpt.map(_.workerCache).getOrElse(Map.empty),
-          nestedState.frames.headOption.map(_.codeSignatures).getOrElse(Map.empty),
-          rootModule,
-          // We want to use the grandparent buildHash, rather than the parent
-          // buildHash, because the parent build changes are instead detected
-          // by analyzing the scriptImportGraph in a more fine-grained manner.
-          nestedState
-            .frames
-            .dropRight(1)
-            .headOption
-            .map(_.runClasspath)
-            .getOrElse(millBootClasspathPathRefs)
-            .map(p => (p.path, p.sig))
-            .hashCode(),
-          nestedState
-            .frames
-            .headOption
-            .flatMap(_.classLoaderOpt)
-            .map(_.hashCode())
-            .getOrElse(0),
-          depth,
-          actualBuildFileName = nestedState.buildFile
-        )) { evaluator =>
-          if (depth == requestedDepth) processFinalTargets(nestedState, rootModule, evaluator)
-          else if (depth <= requestedDepth) nestedState
-          else {
-            processRunClasspath(
-              nestedState,
+        mill.constants.DebugLog.println("rootModuleRes")
+        val rootModuleRes = nestedState.frames.headOption match {
+          case None => Result.Success(nestedState.bootstrapModuleOpt.get)
+          case Some(nestedFrame) =>
+            try Result.Success(getRootModule(nestedFrame.classLoaderOpt.get))
+            catch {
+              case e: Throwable => Result.Failure(renderFailure(e))
+            }
+        }
+
+        rootModuleRes match {
+          case Result.Failure(err) => nestedState.add(errorOpt = Some(err))
+          case Result.Success(rootModule) =>
+
+            Using.resource(makeEvaluator(
+              prevFrameOpt.map(_.workerCache).getOrElse(Map.empty),
+              nestedState.frames.headOption.map(_.codeSignatures).getOrElse(Map.empty),
               rootModule,
-              evaluator,
-              prevFrameOpt,
-              prevOuterFrameOpt
-            )
-          }
+              // We want to use the grandparent buildHash, rather than the parent
+              // buildHash, because the parent build changes are instead detected
+              // by analyzing the scriptImportGraph in a more fine-grained manner.
+              nestedState
+                .frames
+                .dropRight(1)
+                .headOption
+                .map(_.runClasspath)
+                .getOrElse(millBootClasspathPathRefs)
+                .map(p => (p.path, p.sig))
+                .hashCode(),
+              nestedState
+                .frames
+                .headOption
+                .flatMap(_.classLoaderOpt)
+                .map(_.hashCode())
+                .getOrElse(0),
+              depth,
+              actualBuildFileName = nestedState.buildFile
+            )) { evaluator =>
+              if (depth == requestedDepth) processFinalTargets(nestedState, rootModule, evaluator)
+              else if (depth <= requestedDepth) nestedState
+              else {
+                processRunClasspath(
+                  nestedState,
+                  rootModule,
+                  evaluator,
+                  prevFrameOpt,
+                  prevOuterFrameOpt
+                )
+              }
+            }
         }
       }
 
@@ -484,7 +511,9 @@ object MillBuildBootstrap {
 
   def getRootModule(runClassLoader: URLClassLoader): RootModule = {
     val buildClass = runClassLoader.loadClass(s"$globalPackagePrefix.${wrapperObjectName}$$")
-    buildClass.getField("MODULE$").get(buildClass).asInstanceOf[RootModule]
+    os.checker.withValue(EvaluatorImpl.resolveChecker) {
+      buildClass.getField("MODULE$").get(buildClass).asInstanceOf[RootModule]
+    }
   }
 
   def recRoot(projectRoot: os.Path, depth: Int): os.Path = {

--- a/scalalib/src/mill/javalib/android/AndroidLibModule.scala
+++ b/scalalib/src/mill/javalib/android/AndroidLibModule.scala
@@ -95,7 +95,7 @@ trait AndroidLibModule extends AndroidModule with PublishModule {
     )
 
     os.move(classesJar, unpackedAar / "classes.jar", replaceExisting = true)
-    os.move(
+    os.copy(
       androidMergedManifest().path,
       unpackedAar / "AndroidManifest.xml",
       replaceExisting = true

--- a/scalalib/src/mill/scalalib/TestModuleUtil.scala
+++ b/scalalib/src/mill/scalalib/TestModuleUtil.scala
@@ -62,20 +62,22 @@ private[scalalib] object TestModuleUtil {
 
       os.makeDir.all(sandbox)
 
-      Jvm.callProcess(
-        mainClass = "mill.testrunner.entrypoint.TestRunnerMain",
-        classPath = (runClasspath ++ testrunnerEntrypointClasspath).map(_.path),
-        jvmArgs = jvmArgs,
-        env = forkEnv ++ resourceEnv,
-        mainArgs = Seq(testRunnerClasspathArg, argsFile.toString),
-        cwd = if (testSandboxWorkingDir) sandbox else forkWorkingDir,
-        cpPassingJarPath = Option.when(useArgsFile)(
-          os.temp(prefix = "run-", suffix = ".jar", deleteOnExit = false)
-        ),
-        javaHome = javaHome,
-        stdin = os.Inherit,
-        stdout = os.Inherit
-      )
+      os.checker.withValue(os.Checker.Nop) {
+        Jvm.callProcess(
+          mainClass = "mill.testrunner.entrypoint.TestRunnerMain",
+          classPath = (runClasspath ++ testrunnerEntrypointClasspath).map(_.path),
+          jvmArgs = jvmArgs,
+          env = forkEnv ++ resourceEnv,
+          mainArgs = Seq(testRunnerClasspathArg, argsFile.toString),
+          cwd = if (testSandboxWorkingDir) sandbox else forkWorkingDir,
+          cpPassingJarPath = Option.when(useArgsFile)(
+            os.temp(prefix = "run-", suffix = ".jar", deleteOnExit = false)
+          ),
+          javaHome = javaHome,
+          stdin = os.Inherit,
+          stdout = os.Inherit
+        )
+      }
 
       if (!os.exists(outputPath))
         Result.Failure(s"Test reporting Failed: ${outputPath} does not exist")

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -154,13 +154,13 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     )
   }
   // Location of the clang compiler
-  def nativeClang = Task {
-    os.Path(withScalaNativeBridge.apply().apply(_.discoverClang()))
+  def nativeClang: T[PathRef] = Task {
+    PathRef(os.Path(withScalaNativeBridge.apply().apply(_.discoverClang())))
   }
 
   // Location of the clang++ compiler
-  def nativeClangPP = Task {
-    os.Path(withScalaNativeBridge.apply().apply(_.discoverClangPP()))
+  def nativeClangPP: T[PathRef] = Task {
+    PathRef(os.Path(withScalaNativeBridge.apply().apply(_.discoverClangPP())))
   }
 
   // GC choice, either "none", "boehm", "immix" or "commix"
@@ -231,8 +231,8 @@ trait ScalaNativeModule extends ScalaModule { outer =>
       finalMainClassOpt(),
       classpath.map(_.toIO),
       nativeWorkdir().toIO,
-      nativeClang().toIO,
-      nativeClangPP().toIO,
+      nativeClang().path.toIO,
+      nativeClangPP().path.toIO,
       nativeTarget(),
       nativeCompileOptions(),
       nativeLinkingOptions(),
@@ -270,17 +270,17 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     }
 
   // Generates native binary
-  def nativeLink = Task {
-    os.Path(withScalaNativeBridge.apply().apply(_.nativeLink(
+  def nativeLink: T[PathRef] = Task {
+    PathRef(os.Path(withScalaNativeBridge.apply().apply(_.nativeLink(
       nativeConfig().config,
       Task.dest.toIO
-    )))
+    ))))
   }
 
   // Runs the native binary
   override def run(args: Task[Args] = Task.Anon(Args())) = Task.Command {
     os.call(
-      cmd = Vector(nativeLink().toString) ++ args().value,
+      cmd = nativeLink().path.toString +: args().value,
       env = forkEnv(),
       cwd = forkWorkingDir(),
       stdin = os.Inherit,
@@ -373,7 +373,7 @@ trait TestScalaNativeModule extends ScalaNativeModule with TestModule {
   ): Task[(String, Seq[TestResult])] = Task.Anon {
 
     val (close, framework) = withScalaNativeBridge.apply().apply(_.getFramework(
-      nativeLink().toIO,
+      nativeLink().path.toIO,
       forkEnv() ++
         Map(
           EnvVars.MILL_TEST_RESOURCE_DIR -> resources().map(_.path).mkString(";"),


### PR DESCRIPTION
Add support for super task resolution in Mill

Implement enhanced task resolution for super tasks, allowing:
- Direct super task resolution
- Qualified super task resolution across module hierarchies
- Preserving original selector for qualified super tasks

Changes include:
- Modifying `Resolve` to handle super task selectors
- Updating `ResolveCore` to support super task resolution
- Adding comprehensive test cases for super task resolution in different module hierarchies
